### PR TITLE
Makefileの整備

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: up
+up:
+	docker compose up -d
+
+.PHONY: down
+down:
+	docker compose down
+
+.PHONY: console
+console:
+	@docker compose exec console go run main.go

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Y-III: 故障を乗り越えて動くシステムのための分散合意
 
+## 必要環境
+
+- Docker (Docker Compose)
+- make
+
+## 開発の進め方
+
+- `make up`
+  - Docker Composeで開発環境を建てる
+  - Dispatcher×1、Console×1、Peer×5が同じネットワーク内に建つ
+- `make down`
+  - `make up`で建てた開発環境を削除する
+- `make console`
+  - 分散システムを操作するためのコンソールを起動する

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -21,6 +21,10 @@ func main() {
 	dispatcherFlag := flag.String("dispatcher", "localhost:8080", "Dispatcher address")
 	flag.Parse()
 
+	if *dispatcherFlag == "localhost:8080" && os.Getenv("DISPATCHER") != "" {
+		*dispatcherFlag = os.Getenv("DISPATCHER")
+	}
+
 	var err error
 	disp, err = dispatcher.FindDispatcher(*dispatcherFlag)
 	if err != nil {

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -17,13 +17,17 @@ var (
 	disp *dispatcher.Client
 )
 
-func main() {
-	dispatcherFlag := flag.String("dispatcher", "localhost:8080", "Dispatcher address")
-	flag.Parse()
-
-	if *dispatcherFlag == "localhost:8080" && os.Getenv("DISPATCHER") != "" {
-		*dispatcherFlag = os.Getenv("DISPATCHER")
+func getEnv(key, def string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
 	}
+
+	return def
+}
+
+func main() {
+	dispatcherFlag := flag.String("dispatcher", getEnv("DISPATCHER", "localhost:8080"), "Dispatcher address")
+	flag.Parse()
 
 	var err error
 	disp, err = dispatcher.FindDispatcher(*dispatcherFlag)


### PR DESCRIPTION
- consoleが直接環境変数を読みこむように
  - Makefileの都合上、Flagに乗せられないから
  - Flagを指定した場合、基本的にFlagが優先される(ごくまれに例外アリ)
- Makefileを整備
- REAEDMEにMakefileの内容を記述