### PR TITLE
NodeとWorkerの依存関係を改善

### DIFF
--- a/cmd/peer/main.go
+++ b/cmd/peer/main.go
@@ -56,6 +56,7 @@ func main() {
 	for name, addr := range peers {
 		if name != node.Name() {
 			_ = node.Connect(name, addr)
+			_ = node.ConnectBack(name, addr)
 		}
 	}
 

--- a/dispatcher/client.go
+++ b/dispatcher/client.go
@@ -20,9 +20,9 @@ func FindDispatcher(addr string) (*Client, error) {
 	return d, nil
 }
 
-func (d *Client) GetConnectedPeers(w *peer.Worker) (map[string]string, error) {
+func (d *Client) GetConnectedPeers(n *peer.Node) (map[string]string, error) {
 	var reply RequestConnectReply
-	err := d.client.Call("Dispatcher.RequestConnect", RequestConnectArgs{w.Name(), w.Addr()}, &reply)
+	err := d.client.Call("Dispatcher.RequestConnect", RequestConnectArgs{n.Name(), n.Addr()}, &reply)
 	return reply.Peers, err
 }
 

--- a/peer/consensus.go
+++ b/peer/consensus.go
@@ -24,11 +24,10 @@ type RequestStateReply struct {
 }
 
 func (w *Worker) RequestState(args RequestStateArgs, reply *RequestStateReply) error {
-	w.LockMutex()
-	reply.State = w.State
-	w.UnlockMutex()
+	w.mu.Lock()
+	reply.State = w.state
+	w.mu.Unlock()
 
 	log.Println(reply.State.String())
-
 	return nil
 }

--- a/peer/node.go
+++ b/peer/node.go
@@ -10,25 +10,28 @@ import (
 	"time"
 )
 
-type ConnectedNode struct {
+type connectedNode struct {
 	addr string
 	conn *rpc.Client
 }
 
 type Node struct {
+	name string
 	addr string
 
 	listener net.Listener
 	server   *rpc.Server
-	peers    map[string]*ConnectedNode
+	peers    map[string]*connectedNode
 
 	mu sync.Mutex
 	wg sync.WaitGroup
 
 	rnd *rand.Rand
 
-	worker *Worker
-	quit   chan interface{}
+	worker      *Worker
+	callChan    <-chan *Call
+	connectChan <-chan *Connect
+	quit        chan interface{}
 
 	delay int
 }
@@ -41,74 +44,111 @@ func Delay(t int) NodeOption {
 	}
 }
 
-func NewNode(addr string, options ...NodeOption) *Node {
-	n := new(Node)
+func NewNode(name, addr string, callChan <-chan *Call, connectChan <-chan *Connect, worker *Worker, options ...NodeOption) (n *Node, err error) {
+	n = new(Node)
+
+	n.name = name
 	n.addr = addr
-	n.peers = make(map[string]*ConnectedNode)
+	n.peers = make(map[string]*connectedNode)
 	n.delay = 0
 	n.quit = make(chan interface{})
 	n.rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
+	n.worker = worker
+	n.callChan = callChan
+	n.connectChan = connectChan
+	n.server = rpc.NewServer()
+	err = n.server.RegisterName("Worker", n.worker)
+	if err != nil {
+		return nil, err
+	}
+	n.listener, err = net.Listen("tcp", n.addr)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, opt := range options {
 		opt(n)
 	}
-	return n
+
+	return
+}
+
+func (n *Node) Name() string {
+	return n.name
 }
 
 func (n *Node) Addr() string {
 	return n.addr
 }
 
-func (n *Node) Connect(name, addr string) error {
-	if n.IsConnectedTo(name) {
-		return fmt.Errorf("Peer '%s' is already reserved", name)
-	}
-	log.Printf("Connect to %s:%s", name, addr)
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	c, err := rpc.Dial("tcp", addr)
-	if err != nil {
-		return err
-	}
-	n.peers[name] = &ConnectedNode{addr, c}
-	return nil
+func (n *Node) isConnectedTo(name string) bool {
+	_, ok := n.peers[name]
+	return ok
 }
 
-func (n *Node) Shutdown() {
-	close(n.quit)
-	n.listener.Close()
-	for name := range n.ConnectedNodes() {
-		_ = n.Disconnect(name)
+func (n *Node) Connect(name, addr string) error {
+	if !n.isConnectedTo(name) {
+		log.Printf("Connect to %s:%s", name, addr)
+		n.mu.Lock()
+		defer n.mu.Unlock()
+
+		c, err := rpc.Dial("tcp", addr)
+		if err != nil {
+			return err
+		}
+
+		n.peers[name] = &connectedNode{addr, c}
+		n.worker.RegisterPeer(name, addr)
 	}
-	n.worker = nil
-	n.wg.Wait()
+
+	var reply RequestConnectReply
+	err := n.call(name, "Worker.RequestConnect", RequestConnectArgs{n.name, n.addr}, &reply)
+	if err != nil {
+		return err
+	} else if !reply.OK {
+		return fmt.Errorf("Connection request denied: [%s] %s", name, addr)
+	}
+
+	log.Printf("Connected to %s:%s", name, addr)
+	return nil
 }
 
 func (n *Node) Disconnect(name string) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	if n.peers[name] != nil {
-		err := n.peers[name].conn.Close()
-		delete(n.peers, name)
-		return err
+
+	if peer, ok := n.peers[name]; !ok || peer == nil {
+		return nil
 	}
-	return nil
-}
 
-func (n *Node) LinkWorker(w *Worker) error {
-	n.mu.Lock()
-	n.worker = w
-	n.worker.LinkNode(n)
-
-	n.server = rpc.NewServer()
-	_ = n.server.RegisterName("Worker", n.worker)
-
-	var err error
-	n.listener, err = net.Listen("tcp", n.addr)
+	err := n.peers[name].conn.Close()
 	if err != nil {
 		return err
 	}
-	n.mu.Unlock()
 
+	delete(n.peers, name)
+	n.worker.UnregisterPeer(name)
+	return nil
+}
+
+func (n *Node) call(name, method string, args any, reply any) error {
+	n.mu.Lock()
+	peer := n.peers[name]
+	n.mu.Unlock()
+	if peer == nil {
+		return fmt.Errorf("No such peer: %s", name)
+	}
+
+	if n.delay > 0 {
+		delay := int(n.rnd.ExpFloat64() / float64(n.delay))
+		time.Sleep(time.Duration(delay) * time.Millisecond)
+	}
+
+	return peer.conn.Call(method, args, reply)
+}
+
+func (n *Node) Run() error {
+	// RPCサーバーを起動
 	n.wg.Add(1)
 	go func() {
 		defer n.wg.Done()
@@ -122,6 +162,7 @@ func (n *Node) LinkWorker(w *Worker) error {
 					log.Fatal(err)
 				}
 			}
+
 			n.wg.Add(1)
 			go func() {
 				n.server.ServeConn(conn)
@@ -130,44 +171,36 @@ func (n *Node) LinkWorker(w *Worker) error {
 		}
 	}()
 
+	// workerからのchanによるリクエストを処理
+	n.wg.Add(1)
+	go func() {
+		defer n.wg.Done()
+		for {
+			select {
+			case <-n.quit:
+				return
+
+			case call := <-n.callChan:
+				err := n.call(call.Name, call.Method, call.Args, call.Reply)
+				call.ErrChan <- err
+
+			case connect := <-n.connectChan:
+				err := n.Connect(connect.Name, connect.Addr)
+				connect.ErrChan <- err
+			}
+		}
+	}()
+
 	return nil
 }
 
-func (n *Node) ConnectedNodes() map[string]string {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	list := make(map[string]string, len(n.peers))
-	for key, value := range n.peers {
-		list[key] = value.addr
-	}
-	return list
-}
+func (n *Node) Shutdown() {
+	close(n.quit)
+	n.listener.Close()
 
-func (n *Node) ConnectedNodeNames() []string {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	ret := make([]string, len(n.peers))
-	for key := range n.peers {
-		ret = append(ret, key)
+	for name := range n.peers {
+		_ = n.Disconnect(name)
 	}
-	return ret
-}
-
-func (n *Node) IsConnectedTo(name string) bool {
-	_, ok := n.peers[name]
-	return ok
-}
-
-func (n *Node) call(name, method string, args any, reply any) error {
-	n.mu.Lock()
-	peer := n.peers[name]
-	n.mu.Unlock()
-	if peer == nil {
-		return fmt.Errorf("No such peer: %s", name)
-	}
-	if n.delay > 0 {
-		delay := int(n.rnd.ExpFloat64() / float64(n.delay))
-		time.Sleep(time.Duration(delay) * time.Millisecond)
-	}
-	return peer.conn.Call(method, args, reply)
+	n.worker = nil
+	n.wg.Wait()
 }

--- a/peer/node.go
+++ b/peer/node.go
@@ -58,10 +58,6 @@ func (n *Node) Addr() string {
 	return n.addr
 }
 
-func (n *Node) Rand() *rand.Rand {
-	return n.rnd
-}
-
 func (n *Node) Connect(name, addr string) error {
 	if n.IsConnectedTo(name) {
 		return fmt.Errorf("Peer '%s' is already reserved", name)
@@ -170,7 +166,7 @@ func (n *Node) call(name, method string, args any, reply any) error {
 		return fmt.Errorf("No such peer: %s", name)
 	}
 	if n.delay > 0 {
-		delay := int(n.Rand().ExpFloat64() / float64(n.delay))
+		delay := int(n.rnd.ExpFloat64() / float64(n.delay))
 		time.Sleep(time.Duration(delay) * time.Millisecond)
 	}
 	return peer.conn.Call(method, args, reply)

--- a/peer/node.go
+++ b/peer/node.go
@@ -114,7 +114,6 @@ func (n *Node) ConnectBack(name, addr string) error {
 		return fmt.Errorf("Connection request denied: [%s] %s", name, addr)
 	}
 
-	log.Printf("Connected to %s:%s", name, addr)
 	return nil
 }
 

--- a/peer/worker.go
+++ b/peer/worker.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"time"
 )
 
 type Worker struct {
 	name  string
 	State WorkerState
 
-	mu sync.Mutex
+	mu  sync.Mutex
+	rnd *rand.Rand
 }
 
 type WorkerOption func(*Worker)
@@ -18,6 +20,7 @@ type WorkerOption func(*Worker)
 func NewWorker(name string) *Worker {
 	w := new(Worker)
 	w.name = name
+	w.rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
 	w.State = InitState(w)
 	return w
 }
@@ -36,10 +39,6 @@ func (w *Worker) LockMutex() {
 
 func (w *Worker) UnlockMutex() {
 	w.mu.Unlock()
-}
-
-func (w *Worker) Rand() *rand.Rand {
-	return w.node.Rand()
 }
 
 func (w *Worker) LinkNode(n *Node) {

--- a/peer/worker.go
+++ b/peer/worker.go
@@ -7,12 +7,10 @@ import (
 )
 
 type Worker struct {
-	name string
-	node *Node
+	name  string
+	State WorkerState
 
 	mu sync.Mutex
-
-	State WorkerState
 }
 
 type WorkerOption func(*Worker)


### PR DESCRIPTION
以前のコードでは相互依存が発生していたため、NodeがWorkerに依存し、WorkerがNodeに何か処理をリクエストする際はチャネルを使って受け渡しするようにした
また、Worker、Node内のフィールドは全てprivateとし、NodeがWorkerのフィールドを変更する・参照する必要があるときはpublicなメソッドを通じて行うこととした

ちょっと不安ポイント
- peersの情報がduplicateしてしまった
  - 本来はNodeにIDと`*rpc.Client`の対応、WorkerにIDとPeerごとの詳細データを入れるみたいなのを想定していた
  - Workerに入れるべき情報があまりなかったためちょっと歪に見える
- チャネルがむしろわかりにくい？
  - 本来チャネルでやるならイベント駆動 (実行が非同期) が理想的だが、今回のケースはそれだと流石にまずいので返り値を渡すチャネルを生成して返してもらうまで待つ感じになっている
  - Node - Worker間の連携は、このクラスでは隠蔽されていていじるものではないという認識なので大丈夫な気はしている
  - 余力あれば今後コメントで解説入れるPRも出します