### PR TITLE
Docker Compose Fileのベストプラクティスを適用

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   dispatcher:
     build: .


### PR DESCRIPTION
https://docs.docker.jp/compose/compose-file/#compose-spec-compose-file

- Compose Fileの最も推奨される名前`compose.yaml`に
- `version`フィールドは非推奨なので削除